### PR TITLE
Fix metadata (especially og tags)

### DIFF
--- a/public/_config.yml
+++ b/public/_config.yml
@@ -1,14 +1,14 @@
 # Site settings
 baseurl: ""
 creator: "The Awesome Foundation"
-description: "We've given out two million dollars in grants!"
+description: "We've given out over two million dollars in grants!"
 email: ""
 github_username:  ""
-logo: "/images/logo.png"
-subject: "Awesome Foundation"
+logo: "/images/header-small.png"
+subject: "The Awesome Foundation"
 title: "$2 million of Awesome Foundation!"
 twitter_username: "@awesomefound"
-url: "http://awesomefoundation.org"
+url: "http://twomillion.awesomefoundation.org"
 copyright: "The Awesome Foundation 2016"
 
 gaTracking: ""


### PR DESCRIPTION
Current `og:` tags are pointing at awesomefoundation.org not twomillion.awesomefoundation.org which is causing problems when posting the link to facebook, etc.

Also edited some header copy to indicate that we've give out _over_ $2M
